### PR TITLE
[Feat] 레이아웃 및 로그인, 메인  페이지 정적 뷰 구현 #18

### DIFF
--- a/hybrid/package-lock.json
+++ b/hybrid/package-lock.json
@@ -16,6 +16,7 @@
         "next": "13.2.4",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-icons": "^4.8.0",
         "styled-components": "^5.3.9",
         "typescript": "5.0.2"
       },
@@ -3290,6 +3291,14 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-icons": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.8.0.tgz",
+      "integrity": "sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -6224,6 +6233,12 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-icons": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.8.0.tgz",
+      "integrity": "sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",

--- a/hybrid/package.json
+++ b/hybrid/package.json
@@ -17,6 +17,7 @@
     "next": "13.2.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-icons": "^4.8.0",
     "styled-components": "^5.3.9",
     "typescript": "5.0.2"
   },

--- a/hybrid/src/components/game/exitButton.tsx
+++ b/hybrid/src/components/game/exitButton.tsx
@@ -1,0 +1,9 @@
+import { ImExit } from 'react-icons/im';
+
+export default function ExitButton() {
+  return (
+    <button>
+      <ImExit />
+    </button>
+  );
+}

--- a/hybrid/src/components/layout/Footer.tsx
+++ b/hybrid/src/components/layout/Footer.tsx
@@ -1,0 +1,8 @@
+export default function Footer() {
+  return (
+    <footer>
+      <p>GitHub | Rule | Contact</p>
+      <p>Copyright © 2023 OkMoK. All rights reserved.</p>
+    </footer>
+  );
+}

--- a/hybrid/src/components/layout/GameLayout.tsx
+++ b/hybrid/src/components/layout/GameLayout.tsx
@@ -1,0 +1,18 @@
+import Header from './Header';
+import Footer from './Footer';
+import ExitButton from '@/components/game/exitButton';
+
+interface GameLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function GameLayout({ children }: GameLayoutProps) {
+  return (
+    <>
+      <Header />
+      <ExitButton />
+      <main>{children}</main>
+      <Footer />
+    </>
+  );
+}

--- a/hybrid/src/components/layout/Header.tsx
+++ b/hybrid/src/components/layout/Header.tsx
@@ -1,0 +1,7 @@
+export default function Header() {
+  return (
+    <header>
+      <h1>OkMoK</h1>
+    </header>
+  );
+}

--- a/hybrid/src/components/layout/Layout.tsx
+++ b/hybrid/src/components/layout/Layout.tsx
@@ -1,0 +1,16 @@
+import Header from './Header';
+import Footer from './Footer';
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+export default function Layout({ children }: LayoutProps) {
+  return (
+    <>
+      <Header />
+      <main>{children}</main>
+      <Footer />
+    </>
+  );
+}

--- a/hybrid/src/components/layout/LoginLayout.tsx
+++ b/hybrid/src/components/layout/LoginLayout.tsx
@@ -1,0 +1,16 @@
+import Header from './Header';
+import Footer from './Footer';
+
+interface LoginLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function LoginLayout({ children }: LoginLayoutProps) {
+  return (
+    <>
+      <Header />
+      <main>{children}</main>
+      <Footer />
+    </>
+  );
+}

--- a/hybrid/src/components/main/PlayButton.tsx
+++ b/hybrid/src/components/main/PlayButton.tsx
@@ -1,0 +1,3 @@
+export default function PlayButton() {
+  return <button>🚀 PLAY</button>;
+}

--- a/hybrid/src/components/main/RoomItem.tsx
+++ b/hybrid/src/components/main/RoomItem.tsx
@@ -1,0 +1,23 @@
+import { ImHome3, ImEnter } from 'react-icons/im';
+
+interface RoomItemProps {
+  number: number;
+  limit: number;
+  players: { player1: string; player2: string };
+}
+
+export default function RoomItem({ number, limit, players }: RoomItemProps) {
+  return (
+    <div>
+      <div>
+        <ImHome3 />
+        {number}
+      </div>
+      <div>{limit}s</div>
+      <div>{players.player1}</div>
+      <div>
+        <ImEnter />
+      </div>
+    </div>
+  );
+}

--- a/hybrid/src/components/main/Rooms.tsx
+++ b/hybrid/src/components/main/Rooms.tsx
@@ -1,0 +1,24 @@
+import RoomItem from './RoomItem';
+
+const dummy = Array.from({ length: 10 }, (_, i) => {
+  return {
+    number: i + 1,
+    limit: 30,
+    players: { player1: 'jabae', player2: 'daekim' },
+  };
+});
+
+export default function Rooms() {
+  return (
+    <div>
+      {dummy.map(({ number, limit, players }) => (
+        <RoomItem
+          key={number}
+          number={number}
+          limit={limit}
+          players={players}
+        />
+      ))}
+    </div>
+  );
+}

--- a/hybrid/src/components/main/SearchBar.tsx
+++ b/hybrid/src/components/main/SearchBar.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import { IoSearch, IoCloseCircle } from 'react-icons/io5';
+
+export default function SearchBar() {
+  const [search, setSearch] = useState('');
+
+  const searchHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const roomValid = /^$|^[0-9]+$/;
+    if (roomValid.test(event.target.value)) setSearch(event.target.value);
+  };
+
+  return (
+    <div>
+      <input
+        type='text'
+        value={search}
+        onChange={searchHandler}
+        maxLength={10}
+        placeholder='방 번호로 입장하기'
+      />
+      <button>
+        <IoSearch />
+      </button>
+    </div>
+  );
+}

--- a/hybrid/src/pages/_app.tsx
+++ b/hybrid/src/pages/_app.tsx
@@ -1,14 +1,27 @@
 import type { AppProps } from 'next/app';
+import type { NextPage } from 'next';
+import type { ReactElement, ReactNode } from 'react';
 import { ThemeProvider } from 'styled-components';
-import GlobalStyle from '@/styles/global-style';
 import { theme } from '@/styles/theme';
+import GlobalStyle from '@/styles/global-style';
+import Layout from '@/components/layout/Layout';
 
-export default function App({ Component, pageProps }: AppProps) {
+export type NextPageWithLayout = NextPage & {
+  getLayout?: (page: ReactElement) => ReactNode;
+};
+
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout;
+};
+
+export default function App({ Component, pageProps }: AppPropsWithLayout) {
+  const getLayout = Component.getLayout ?? ((page) => <Layout>{page}</Layout>);
+
   return (
     <>
       <ThemeProvider theme={theme}>
         <GlobalStyle />
-        <Component {...pageProps} />
+        {getLayout(<Component {...pageProps} />)}
       </ThemeProvider>
     </>
   );

--- a/hybrid/src/pages/_document.tsx
+++ b/hybrid/src/pages/_document.tsx
@@ -36,7 +36,12 @@ class MyDocument extends Document {
   render() {
     return (
       <Html>
-        <Head></Head>
+        <Head>
+          <title>OkMoK</title>
+          <meta name='description' content='OkMoK와 즐거운 오목생활' />
+          <meta name='viewport' content='width=device-width, initial-scale=1' />
+          <link rel='icon' href='/favicon.ico' />
+        </Head>
         <body>
           <Main />
           <NextScript />

--- a/hybrid/src/pages/game.tsx
+++ b/hybrid/src/pages/game.tsx
@@ -1,0 +1,13 @@
+import type { ReactElement } from 'react';
+import type { NextPageWithLayout } from '@/pages/_app';
+import GameLayout from '@/components/layout/GameLayout';
+
+const Game: NextPageWithLayout = () => {
+  return <main>game</main>;
+};
+
+Game.getLayout = function getLayout(page: ReactElement) {
+  return <GameLayout>{page}</GameLayout>;
+};
+
+export default Game;

--- a/hybrid/src/pages/index.tsx
+++ b/hybrid/src/pages/index.tsx
@@ -1,18 +1,17 @@
 import Head from 'next/head';
 import { Inter } from 'next/font/google';
+import SearchBar from '@/components/main/SearchBar';
+import PlayButton from '@/components/main/PlayButton';
+import Rooms from '@/components/main/Rooms';
 
 const inter = Inter({ subsets: ['latin'] });
 
 export default function Home() {
   return (
-    <>
-      <Head>
-        <title>OkMoK</title>
-        <meta name='description' content='OkMoK와 즐거운 오목생활' />
-        <meta name='viewport' content='width=device-width, initial-scale=1' />
-        <link rel='icon' href='/favicon.ico' />
-      </Head>
-      <main> 헬로오목월드 </main>
-    </>
+    <main>
+      <SearchBar />
+      <PlayButton />
+      <Rooms />
+    </main>
   );
 }

--- a/hybrid/src/pages/login.tsx
+++ b/hybrid/src/pages/login.tsx
@@ -1,3 +1,19 @@
-export default function Login() {
-  return <main>login</main>;
-}
+import type { ReactElement } from 'react';
+import type { NextPageWithLayout } from '@/pages/_app';
+import LoginLayout from '@/components/layout/LoginLayout';
+
+const Login: NextPageWithLayout = () => {
+  return (
+    <main>
+      <h1>- - Welcome - -</h1>
+      <h2>Enjoy your game!</h2>
+      <button>Enter ...</button>
+    </main>
+  );
+};
+
+Login.getLayout = function getLayout(page: ReactElement) {
+  return <LoginLayout>{page}</LoginLayout>;
+};
+
+export default Login;


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - ‼️ `react-icons` 설치
  - 각 페이지별 레이아웃 구현
  - 로그인 페이지, 메인 페이지 정적 뷰 구현
 ## ✅ 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 각 페이지별 레이아웃 구현
    - [Nextjs 13 Per-Page Layouts](https://nextjs.org/docs/basic-features/layouts#per-page-layouts) 참고하여 페이지별 레이아웃을 구성했습니다.
    - 확장성을 고려해, `getLayout` 을 정의하지 않으면 기본 `Layout`으로 보여줍니다.
  - 메인 페이지 구현
    - 이전에 @KimDae-hyun 구현했던 코드를 참고해 작성했습니다. https://github.com/OkMoK-co/OkMoK/commit/8ad8c2c9ccc9714d4e48654e7275b6bc76a0eace
  - 로그인 페이지 구현
  - 메타태그 `index` -> `_document` 이동
    - 페이지 전체에 메타태그가 읽히지 않아 코드를 이동시켜주었습니다.
 
