### PR TITLE
[Fix] warning으로 Head 위치 수정

### DIFF
--- a/hybrid/src/pages/_app.tsx
+++ b/hybrid/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import Head from 'next/head';
 import type { AppProps } from 'next/app';
 import type { NextPage } from 'next';
 import type { ReactElement, ReactNode } from 'react';
@@ -19,6 +20,12 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
 
   return (
     <>
+      <Head>
+        <title>OkMoK</title>
+        <meta name='description' content='OkMoK와 즐거운 오목생활' />
+        <meta name='viewport' content='width=device-width, initial-scale=1' />
+        <link rel='icon' href='/favicon.ico' />
+      </Head>
       <ThemeProvider theme={theme}>
         <GlobalStyle />
         {getLayout(<Component {...pageProps} />)}

--- a/hybrid/src/pages/_document.tsx
+++ b/hybrid/src/pages/_document.tsx
@@ -36,12 +36,7 @@ class MyDocument extends Document {
   render() {
     return (
       <Html>
-        <Head>
-          <title>OkMoK</title>
-          <meta name='description' content='OkMoK와 즐거운 오목생활' />
-          <meta name='viewport' content='width=device-width, initial-scale=1' />
-          <link rel='icon' href='/favicon.ico' />
-        </Head>
+        <Head />
         <body>
           <Main />
           <NextScript />


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - warning으로 Head 위치 수정
 ## ✅ 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - _document -> _app 으로 위치 수정했습니다!!
  - 에러 메시지:
    - `Warning: <title> should not be used in _document.js's <Head>. https://nextjs.org/docs/messages/no-document-title`
    - `Warning: viewport meta tags should not be used in _document.js's <Head>. https://nextjs.org/docs/messages/no-document-viewport-meta`
    - 참고: https://nextjs.org/docs/messages/no-document-title
  - 지금은 _app으로 다 옮겨놨는데, 추후에 일부 메타 태그는 _document에 정의하는 방식으로 정리가 필요할 것 같습니다!

 
