### PR TITLE
[Feat] 방 나가면 유저의 ready 초기화 및 게임중 방 나가기 클릭하면 give up 처리 #31

### DIFF
--- a/hybrid/src/components/game/KickoutButton.tsx
+++ b/hybrid/src/components/game/KickoutButton.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { gameInfoState, roomInfoState } from '@/utils/recoil/socket';
 import { socketVar } from '@/socket/variable';
@@ -6,22 +5,17 @@ import { useRequest } from '@/hooks/useRequest';
 import styled from 'styled-components';
 
 export default function KickoutButton() {
+  const sendKickoutHandler = useRequest({ id: socketVar.ROOM_KICKOUT_REQUEST });
   const { startTime } = useRecoilValue(gameInfoState);
   const { player2 } = useRecoilValue(roomInfoState);
-  const [isActivate, setActivate] = useState(false);
-  const sendKickoutHandler = useRequest({ id: socketVar.ROOM_KICKOUT_REQUEST });
-
-  useEffect(() => {
-    if (!startTime && player2) setActivate(true);
-    else setActivate(false);
-  }, [startTime, player2]);
+  const isActive = !startTime && player2;
 
   const kickoutHandler = () => {
-    if (isActivate) sendKickoutHandler();
+    if (isActive) sendKickoutHandler();
   };
 
   return (
-    <Button active={isActivate} onClick={kickoutHandler}>
+    <Button active={isActive} onClick={kickoutHandler}>
       kick out
     </Button>
   );

--- a/hybrid/src/components/game/exitButton.tsx
+++ b/hybrid/src/components/game/exitButton.tsx
@@ -1,12 +1,26 @@
+import { useRecoilValue } from 'recoil';
 import { ImExit } from 'react-icons/im';
 import { socketVar } from '@/socket/variable';
+import { gameInfoState } from '@/utils/recoil/socket';
 import { useRequest } from '@/hooks/useRequest';
 
 export default function ExitButton() {
   const exitRoomHandler = useRequest({ id: socketVar.ROOM_EXIT_REQUEST });
+  const sendGiveUpHandler = useRequest({ id: socketVar.GAME_GIVEUP_REQUEST });
+  const { startTime } = useRecoilValue(gameInfoState);
+  const guide =
+    'If you leave now, it will count as if you abandoned the game.\n Still want to get out?';
+
+  const processExit = () => {
+    if (startTime) {
+      if (window.confirm(guide)) sendGiveUpHandler();
+      else return;
+    }
+    exitRoomHandler();
+  };
 
   return (
-    <button onClick={exitRoomHandler}>
+    <button onClick={processExit}>
       <ImExit />
     </button>
   );

--- a/hybrid/src/socket/responseHandler.tsx
+++ b/hybrid/src/socket/responseHandler.tsx
@@ -96,7 +96,7 @@ export function infoRoomHandler({
 }
 
 export function exitRoomHandler({
-  packet: { option, router },
+  packet: { id, option, router },
   setResponse,
 }: routeResponseProps) {
   if (!option) {
@@ -104,11 +104,13 @@ export function exitRoomHandler({
     return;
   }
 
+  setResponse((prev) => ({ ...prev, packetId: id }));
+
   router.push('/');
 }
 
 export function kickoutUserHandler({
-  packet: { option, router },
+  packet: { option },
   setResponse,
 }: routeResponseProps) {
   if (!option) {
@@ -129,7 +131,7 @@ export function kickedoutUserHandler({
 }
 
 export function readyHandler({
-  packet: { data, id, option },
+  packet: { id, option },
   setResponse,
 }: routeResponseProps) {
   if (!option) {

--- a/hybrid/src/socket/routeResponse.ts
+++ b/hybrid/src/socket/routeResponse.ts
@@ -28,10 +28,10 @@ export const routeResponse: {
   [socketVar.ROOM_ENTER_RESPONSE]: enterRoomHandler,
   [socketVar.ROOM_INFO_RESPONSE]: infoRoomHandler,
   [socketVar.R_ROOM_INFO_RESPONSE]: infoRoomHandler,
+  [socketVar.ROOM_READY_RESPONSE]: readyHandler,
   [socketVar.ROOM_EXIT_RESPONSE]: exitRoomHandler,
   [socketVar.ROOM_KICKOUT_RESPONSE]: kickoutUserHandler,
   [socketVar.R_ROOM_EXIT_RESPONSE]: kickedoutUserHandler,
-  [socketVar.ROOM_READY_RESPONSE]: readyHandler,
 
   [socketVar.R_GAME_START_RESPONSE]: startGameHandler,
   [socketVar.GAME_PUT_RESPONSE]: putHandler,

--- a/hybrid/src/utils/recoil/socket.ts
+++ b/hybrid/src/utils/recoil/socket.ts
@@ -35,6 +35,9 @@ export const responseState = selector<any>({
       case socketVar.ROOM_READY_RESPONSE:
         set(gameInfoState, (get) => ({ ...get, ready: !get.ready }));
         break;
+      case socketVar.ROOM_EXIT_RESPONSE:
+        set(gameInfoState, (get) => ({ ...get, ready: false }));
+        break;
       case socketVar.R_GAME_START_RESPONSE:
       case socketVar.R_GAME_RESULT_RESPONSE:
         set(gameInfoState, newValue.data);

--- a/socketserver/app/srcs/packet/PacketManager.hpp
+++ b/socketserver/app/srcs/packet/PacketManager.hpp
@@ -26,6 +26,7 @@ class PacketManager
 		template <typename T>
 		void makeInfoRoom(T &packet, Poco::Int32 roomIndex);
 		void broadcastInfoRoom(Poco::Int32 roomIndex);
+		void broadcastGameStart(Poco::Int32 gameIndex, std::list<User*>users);
 
 		void processDevEcho(Poco::Int32 connIndex, char* pBodyData, Poco::Int16 bodySize);
 		void processLogin(Poco::Int32 connIndex, char* pBodyData, Poco::Int16 bodySize);

--- a/socketserver/app/srcs/room/Room.cpp
+++ b/socketserver/app/srcs/room/Room.cpp
@@ -52,12 +52,6 @@ std::list<User*> Room::getUsers()
 
 void Room::enterUser(User *user)
 {
-    if (_currentUserCount >= _maxUserCount)
-		{
-        /* 방 들어가기 실패 패킷 보내기*/
-        return ;
-    }
-		
     _users.push_back(user);
     user->enterRoom(_roomIndex);
     _currentUserCount = _users.size();
@@ -65,13 +59,8 @@ void Room::enterUser(User *user)
 
 void Room::leaveUser(User *user)
 {
-    if (_currentUserCount <= 0)
-		{
-        /* 방 나가기 실패 패킷 보내기*/
-        return ;
-    }
-
-    _users.remove(user);
+		_users.remove(user);
+    user->unReady();
     user->leaveRoom();
     _currentUserCount = _users.size();
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 방 나가면 유저의 ready 초기화 
  - 게임중 방 나가기 클릭하면 give up 처리
 ## ✅ 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  백

  - 방 나가면 unReady 상태 만들어주는 코드 추가
  - (리팩토링) 게임중임을 확인 코드를 `_gameManager.takeGameByGameIndex(gameIndex)->getStartTime() != 0` -> `gameIndex != -1` 로 바꾸었습니다: 게임 시작 시간을 확인할 필요가 없습니다. gameIndex는 게임이 끝나면 -1로 초기화 되므로!
  - (리팩토링) `broadcastGameStart`를 추가했습니다.
 
 프론트

  - 방 나가면 응답 받고 `socket response selector`에서 `ready: false` 로 초기화
  - 게임 중 방 나갔을 때, confirm 창을 띄워줍니다.
    - Yes: give up 요청 후, exit 처리
    - No: return(머물기)
  - (리팩토링) atom이 업데이트되면 각각 구독된 컴포넌트는 새로운 값을 반영하여 다시 렌더링 됩니다. 따라서 불필요한 state, useEffect를 삭제했습니다. 
 
  - 추후 뒤로가기, 새로고침을 막을 예정입니다.

 
