### PR TITLE
[Refactor] Timer의 중복되는 turn정보 코드 제거 및 useTurn의 필요없는 useEffect 제거#32

### DIFF
--- a/hybrid/src/components/game/Timer.tsx
+++ b/hybrid/src/components/game/Timer.tsx
@@ -2,31 +2,17 @@ import styled from 'styled-components';
 import useTimer from '@/hooks/useTimer';
 import { SEC } from '@/utils/constants';
 import { useRecoilValue } from 'recoil';
-import {
-  gameInfoState,
-  putInfoState,
-  roomInfoState,
-} from '@/utils/recoil/socket';
-import { useEffect, useState } from 'react';
+import { roomInfoState } from '@/utils/recoil/socket';
+import useTurn from '@/hooks/useTurn';
 
 interface TimerProps {
   player: number;
 }
 
 export default function Timer({ player }: TimerProps) {
-  const { startTime } = useRecoilValue(gameInfoState);
-  const putInfo = useRecoilValue(putInfoState);
   const { limitTime } = useRecoilValue(roomInfoState);
-  const [active, setActive] = useState(false);
-  const { timer } = useTimer({ active: active });
-
-  useEffect(() => {
-    if (startTime) {
-      if (!putInfo.player && player === 1) setActive(true);
-      else if (putInfo.player && putInfo.player !== player) setActive(true);
-      else setActive(false);
-    } else setActive(false);
-  }, [startTime, putInfo]);
+  const { isMyTurn: active } = useTurn(player);
+  const { timer } = useTimer({ active });
 
   return (
     <div>

--- a/hybrid/src/hooks/useDrawOkmok.tsx
+++ b/hybrid/src/hooks/useDrawOkmok.tsx
@@ -9,7 +9,9 @@ export default function useDrawOkmok() {
   const putInfo = useRecoilValue(putInfoState);
   const { startTime } = useRecoilValue(gameInfoState);
   const [pointXY, setPointXY] = useState<number[]>([-1, -1]);
-  const initBoard = Array.from(Array(15), () => new Array(15).fill(0));
+  const initBoard: number[][] = Array.from(Array(15), () =>
+    new Array(15).fill(0)
+  );
   const [board, setBoard] = useState<number[][]>(initBoard);
   const [isStart, setIsStart] = useState<boolean>(false);
 
@@ -17,6 +19,7 @@ export default function useDrawOkmok() {
     setIsStart(!!startTime);
     clearPointCanvas();
   }, [startTime]);
+
   useEffect(() => {
     if (!isStart) return;
     const canvas = canvasRef.current;

--- a/hybrid/src/hooks/useTurn.tsx
+++ b/hybrid/src/hooks/useTurn.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useRecoilValue, useResetRecoilState } from 'recoil';
 import {
   gameInfoState,
@@ -7,26 +7,22 @@ import {
   roomInfoState,
 } from '@/utils/recoil/socket';
 
-export default function useTurn() {
+export default function useTurn(player?: number) {
   const { startTime } = useRecoilValue(gameInfoState);
   const { nickname } = useRecoilValue(userState);
   const { player1 } = useRecoilValue(roomInfoState);
   const putInfo = useRecoilValue(putInfoState);
   const resetPutInfo = useResetRecoilState(putInfoState);
-  const [isMyTurn, setIsMyTurn] = useState(false);
-  const [player, setPlayer] = useState(0);
-
-  useEffect(() => {
+  if (!player) player = player1 === nickname ? 1 : 2;
+  const getMyTurn = () => {
     if (startTime) {
-      if (!putInfo.player && player === 1) setIsMyTurn(true);
-      else if (putInfo.player && player !== putInfo.player) setIsMyTurn(true);
-      else setIsMyTurn(false);
-    } else setIsMyTurn(false);
-  }, [putInfo, startTime]);
-  useEffect(() => {
-    if (player1 === nickname) setPlayer(1);
-    else setPlayer(2);
-  }, [player1]);
+      if (!putInfo.player && player === 1) return true;
+      else if (putInfo.player && player !== putInfo.player) return true;
+      else return false;
+    } else return false;
+  };
+  const isMyTurn = getMyTurn();
+
   useEffect(() => {
     resetPutInfo();
   }, [startTime]);


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 중복코드 제거
 ## ✅ 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - Timer의 active를 useTurn 훅을 이용할 수 있도록 훅을 바꿨습니다!
  - useTurn에서 useEffect를 사용하지 않아도 되는 부분을 바꿨습니다~

 
